### PR TITLE
Fix help usage message

### DIFF
--- a/cat/cli.rb
+++ b/cat/cli.rb
@@ -12,7 +12,7 @@ class Cli
     opt.parse!(argv)
 
     if argv.empty?
-      puts 'Usage: cagt [options] [file ...]'
+      puts 'Usage: cat [options] [file ...]'
       exit 1
     end
 


### PR DESCRIPTION
## Summary
- fix a typo in the CLI usage message

## Testing
- `ruby tests/cat.rb`


------
